### PR TITLE
Hookup Timber for logging

### DIFF
--- a/mobile/src/androidTest/java/com/truckmuncher/truckmuncher/LoggerStarterTest.java
+++ b/mobile/src/androidTest/java/com/truckmuncher/truckmuncher/LoggerStarterTest.java
@@ -1,0 +1,31 @@
+package com.truckmuncher.truckmuncher;
+
+import android.content.Context;
+import android.test.AndroidTestCase;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.List;
+
+import timber.log.Timber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LoggerStarterTest extends AndroidTestCase {
+
+    public void testStartMethodIsSynchronized() throws NoSuchMethodException {
+        Method method = LoggerStarter.class.getMethod("start", Context.class);
+        assertThat(Modifier.isSynchronized(method.getModifiers())).isTrue();
+    }
+
+    public void testLoggersAreOnlyBeSetupOnce() throws NoSuchFieldException, IllegalAccessException {
+        LoggerStarter.start(getContext());
+        LoggerStarter.start(getContext());
+
+        Field loggers = Timber.class.getDeclaredField("FOREST");
+        loggers.setAccessible(true);
+        List<Timber.Tree> trees = (List<Timber.Tree>) loggers.get(null);
+        assertThat(trees).hasSize(1);
+    }
+}

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"

--- a/mobile/src/main/java/com/truckmuncher/truckmuncher/App.java
+++ b/mobile/src/main/java/com/truckmuncher/truckmuncher/App.java
@@ -1,0 +1,12 @@
+package com.truckmuncher.truckmuncher;
+
+import android.app.Application;
+
+public class App extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        LoggerStarter.start(this);
+    }
+}

--- a/mobile/src/main/java/com/truckmuncher/truckmuncher/LoggerStarter.java
+++ b/mobile/src/main/java/com/truckmuncher/truckmuncher/LoggerStarter.java
@@ -1,0 +1,38 @@
+package com.truckmuncher.truckmuncher;
+
+import android.content.Context;
+
+import com.crashlytics.android.Crashlytics;
+import com.volkhart.androidutil.reporting.CrashlyticsTree;
+
+import timber.log.Timber;
+
+/**
+ * Use the logger starter to setup logging from anywhere in the system, ensuring that the logging
+ * system is only configured once. This is especially useful in instances where a component may be
+ * disconnected from the regular app lifecycle, as is the case with ContentProviders.
+ */
+public final class LoggerStarter {
+
+    private static boolean hasStarted;
+
+    private LoggerStarter() {
+        // No instances
+    }
+
+    public static synchronized void start(Context context) {
+        if (context == null) {
+            throw new IllegalArgumentException("Context may not be null");
+        }
+        if (!hasStarted) {
+            if (BuildConfig.DEBUG) {
+                Timber.plant(new Timber.DebugTree());
+            } else {
+                Crashlytics.start(context);
+                Timber.plant(new CrashlyticsTree());
+            }
+            hasStarted = true;
+        }
+    }
+
+}


### PR DESCRIPTION
`Timber` is a utility to wrap logging. It ensures that we have consistent messages, takes care of tagging, and doesn't dump to log in production.

@nockertsb please review
