### PR TITLE
Better verifiable content provider

### DIFF
--- a/mobile/src/androidTest/java/com/truckmuncher/truckmuncher/test/data/VerifiableContentProvider.java
+++ b/mobile/src/androidTest/java/com/truckmuncher/truckmuncher/test/data/VerifiableContentProvider.java
@@ -6,6 +6,8 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.test.mock.MockContentProvider;
 
+import org.assertj.android.api.Assertions;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -50,6 +52,13 @@ public class VerifiableContentProvider extends MockContentProvider {
         DeleteEvent event = deleteEvents.poll();
         assertThat(event).isNotNull();
         return event.onDelete(uri, selection, selectionArgs);
+    }
+
+    @Override
+    public int bulkInsert(Uri uri, ContentValues[] values) {
+        BulkInsertEvent event = bulkInsertEvents.poll();
+        assertThat(event).isNotNull();
+        return event.onBulkInsert(uri, values);
     }
 
     public VerifiableContentProvider enqueue(UpdateEvent event) {
@@ -98,7 +107,7 @@ public class VerifiableContentProvider extends MockContentProvider {
 
     public VerifiableContentProvider assertThatCursorsAreClosed() {
         for (Cursor cursor : expiredCursors) {
-            assertThat(cursor.isClosed()).isTrue();
+            Assertions.assertThat(cursor).isClosed();
         }
         return this;
     }


### PR DESCRIPTION
@nockertsb please review
- Adds documentation to the `VerifiableContentProvider` in the form of annotations. This will be picked up by the IDE which is nice. 
- Rename `verify` to `assertThatQueuesAreEmpty`. It reveals an implementation aspect but it's more documenting and reflective of how the system works.
- Support for BulkInsert operations
- Better error messages
- Adds the ability to verify cursors. This is useful because the test fixture doesn't need to hold onto the cursor, which gets to be messy. Instead, the content provider does. The feature is important because when not using the Loader Framework, we have to make sure we close cursors ourselves.

I really wanted to bundle the cursor verification behavior with the queue verification behavior, but I think that will be a problem once we run UI tests since the activity typically doesn't get finished until `tearDown` is called. This means that the cursor will and should still be open when the test ends if using the Loader Framework.
